### PR TITLE
fixup! platform: nordic nrf: fix review comments and converting tabs …

### DIFF
--- a/platform/ext/target/nordic_nrf/common/native_drivers/spu.c
+++ b/platform/ext/target/nordic_nrf/common/native_drivers/spu.c
@@ -25,9 +25,9 @@
 #define SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID  64
 
 #define NUM_FLASH_SECURE_ATTRIBUTION_REGIONS \
-	(FLASH_TOTAL_SIZE / FLASH_SECURE_ATTRIBUTION_REGION_SIZE)
+    (FLASH_TOTAL_SIZE / FLASH_SECURE_ATTRIBUTION_REGION_SIZE)
 #define NUM_SRAM_SECURE_ATTRIBUTION_REGIONS \
-	(TOTAL_RAM_SIZE / SRAM_SECURE_ATTRIBUTION_REGION_SIZE)
+    (TOTAL_RAM_SIZE / SRAM_SECURE_ATTRIBUTION_REGION_SIZE)
 
 #define DEVICE_FLASH_BASE_ADDRESS FLASH_BASE_ADDRESS
 #define DEVICE_SRAM_BASE_ADDRESS SRAM_BASE_ADDRESS
@@ -40,13 +40,13 @@
  * addr shall be a valid flash memory address
  */
 #define FLASH_NSC_REGION_FROM_ADDR(addr) \
-	((uint32_t)addr / FLASH_SECURE_ATTRIBUTION_REGION_SIZE)
+    ((uint32_t)addr / FLASH_SECURE_ATTRIBUTION_REGION_SIZE)
 
 /*
  * Determine the NSC region size based on a given NCS region base address.
  */
 #define FLASH_NSC_SIZE_FROM_ADDR(addr) (FLASH_SECURE_ATTRIBUTION_REGION_SIZE \
-	- (((uint32_t)(addr)) % FLASH_SECURE_ATTRIBUTION_REGION_SIZE))
+    - (((uint32_t)(addr)) % FLASH_SECURE_ATTRIBUTION_REGION_SIZE))
 
 /*
  * Determine the encoded the SPU NCS Region Size value,
@@ -59,198 +59,198 @@
 
 void spu_enable_interrupts(void)
 {
-	nrf_spu_int_enable(NRF_SPU,
-		NRF_SPU_INT_FLASHACCERR_MASK |
-		NRF_SPU_INT_RAMACCERR_MASK |
-		NRF_SPU_INT_PERIPHACCERR_MASK);
+    nrf_spu_int_enable(NRF_SPU,
+        NRF_SPU_INT_FLASHACCERR_MASK |
+        NRF_SPU_INT_RAMACCERR_MASK |
+        NRF_SPU_INT_PERIPHACCERR_MASK);
 }
 
 void spu_clear_events(void)
 {
-	nrf_spu_event_clear(NRF_SPU, NRF_SPU_EVENT_RAMACCERR);
-	nrf_spu_event_clear(NRF_SPU, NRF_SPU_EVENT_FLASHACCERR);
-	nrf_spu_event_clear(NRF_SPU, NRF_SPU_EVENT_PERIPHACCERR);
+    nrf_spu_event_clear(NRF_SPU, NRF_SPU_EVENT_RAMACCERR);
+    nrf_spu_event_clear(NRF_SPU, NRF_SPU_EVENT_FLASHACCERR);
+    nrf_spu_event_clear(NRF_SPU, NRF_SPU_EVENT_PERIPHACCERR);
 }
 
 void spu_regions_reset_all_secure(void)
 {
-	for (size_t i = 0; i < NUM_FLASH_SECURE_ATTRIBUTION_REGIONS ; i++) {
-		nrf_spu_flashregion_set(NRF_SPU, i,
-			1 /* Secure */,
-			NRF_SPU_MEM_PERM_READ
-			| NRF_SPU_MEM_PERM_WRITE
-			| NRF_SPU_MEM_PERM_EXECUTE,
-			0 /* No lock */);
-	}
+    for (size_t i = 0; i < NUM_FLASH_SECURE_ATTRIBUTION_REGIONS ; i++) {
+        nrf_spu_flashregion_set(NRF_SPU, i,
+            1 /* Secure */,
+            NRF_SPU_MEM_PERM_READ
+            | NRF_SPU_MEM_PERM_WRITE
+            | NRF_SPU_MEM_PERM_EXECUTE,
+            0 /* No lock */);
+    }
 
-	for (size_t i = 0; i < NUM_SRAM_SECURE_ATTRIBUTION_REGIONS ; i++) {
-		nrf_spu_ramregion_set(NRF_SPU, i,
-			1 /* Secure */,
-			NRF_SPU_MEM_PERM_READ
-			| NRF_SPU_MEM_PERM_WRITE
-			| NRF_SPU_MEM_PERM_EXECUTE,
-			0 /* No lock */);
-	}
+    for (size_t i = 0; i < NUM_SRAM_SECURE_ATTRIBUTION_REGIONS ; i++) {
+        nrf_spu_ramregion_set(NRF_SPU, i,
+            1 /* Secure */,
+            NRF_SPU_MEM_PERM_READ
+            | NRF_SPU_MEM_PERM_WRITE
+            | NRF_SPU_MEM_PERM_EXECUTE,
+            0 /* No lock */);
+    }
 }
 
 void spu_regions_flash_config_non_secure(uint32_t start_addr, uint32_t limit_addr)
 {
-	/* Determine start and last flash region number */
-	size_t start_id =
-		(start_addr - DEVICE_FLASH_BASE_ADDRESS) /
-			FLASH_SECURE_ATTRIBUTION_REGION_SIZE;
-	size_t last_id =
-		(limit_addr - DEVICE_FLASH_BASE_ADDRESS) /
-			FLASH_SECURE_ATTRIBUTION_REGION_SIZE;
+    /* Determine start and last flash region number */
+    size_t start_id =
+        (start_addr - DEVICE_FLASH_BASE_ADDRESS) /
+            FLASH_SECURE_ATTRIBUTION_REGION_SIZE;
+    size_t last_id =
+        (limit_addr - DEVICE_FLASH_BASE_ADDRESS) /
+            FLASH_SECURE_ATTRIBUTION_REGION_SIZE;
 
-	/* Configure all flash regions between start_id and last_id */
-	for (size_t i = start_id; i <= last_id; i++) {
-		nrf_spu_flashregion_set(NRF_SPU, i,
-			0 /* Non-Secure */,
-			NRF_SPU_MEM_PERM_READ
-			| NRF_SPU_MEM_PERM_WRITE
-			| NRF_SPU_MEM_PERM_EXECUTE,
-			1 /* Lock */);
-	}
+    /* Configure all flash regions between start_id and last_id */
+    for (size_t i = start_id; i <= last_id; i++) {
+        nrf_spu_flashregion_set(NRF_SPU, i,
+            0 /* Non-Secure */,
+            NRF_SPU_MEM_PERM_READ
+            | NRF_SPU_MEM_PERM_WRITE
+            | NRF_SPU_MEM_PERM_EXECUTE,
+            1 /* Lock */);
+    }
 }
 
 void spu_regions_sram_config_non_secure(uint32_t start_addr, uint32_t limit_addr)
 {
-	/* Determine start and last ram region number */
-	size_t start_id =
-		(start_addr - DEVICE_SRAM_BASE_ADDRESS) /
-			SRAM_SECURE_ATTRIBUTION_REGION_SIZE;
-	size_t last_id =
-		(limit_addr - DEVICE_SRAM_BASE_ADDRESS) /
-			SRAM_SECURE_ATTRIBUTION_REGION_SIZE;
+    /* Determine start and last ram region number */
+    size_t start_id =
+        (start_addr - DEVICE_SRAM_BASE_ADDRESS) /
+            SRAM_SECURE_ATTRIBUTION_REGION_SIZE;
+    size_t last_id =
+        (limit_addr - DEVICE_SRAM_BASE_ADDRESS) /
+            SRAM_SECURE_ATTRIBUTION_REGION_SIZE;
 
-	/* Configure all ram regions between start_id and last_id */
-	for (size_t i = start_id; i <= last_id; i++) {
-		nrf_spu_ramregion_set(NRF_SPU, i,
-			0 /* Non-Secure */,
-			NRF_SPU_MEM_PERM_READ
-			| NRF_SPU_MEM_PERM_WRITE
-			| NRF_SPU_MEM_PERM_EXECUTE,
-			1 /* Lock */);
-	}
+    /* Configure all ram regions between start_id and last_id */
+    for (size_t i = start_id; i <= last_id; i++) {
+        nrf_spu_ramregion_set(NRF_SPU, i,
+            0 /* Non-Secure */,
+            NRF_SPU_MEM_PERM_READ
+            | NRF_SPU_MEM_PERM_WRITE
+            | NRF_SPU_MEM_PERM_EXECUTE,
+            1 /* Lock */);
+    }
 }
 
 void spu_regions_flash_config_non_secure_callable(uint32_t start_addr,
-	uint32_t limit_addr)
+    uint32_t limit_addr)
 {
-	size_t size = limit_addr - start_addr + 1;
+    size_t size = limit_addr - start_addr + 1;
 
-	uint32_t nsc_size = FLASH_NSC_SIZE_FROM_ADDR(start_addr);
+    uint32_t nsc_size = FLASH_NSC_SIZE_FROM_ADDR(start_addr);
 
-	/* Check Non-Secure Callable region possible overflow */
-	NRFX_ASSERT(size <= nsc_size);
+    /* Check Non-Secure Callable region possible overflow */
+    NRFX_ASSERT(size <= nsc_size);
 
-	/* Check Non-Secure Callable region ending on SPU boundary */
-	NRFX_ASSERT(((start_addr + nsc_size) %
-			FLASH_SECURE_ATTRIBUTION_REGION_SIZE) == 0);
+    /* Check Non-Secure Callable region ending on SPU boundary */
+    NRFX_ASSERT(((start_addr + nsc_size) %
+            FLASH_SECURE_ATTRIBUTION_REGION_SIZE) == 0);
 
-	/* Check Non-Secure Callable region power-of-2 size compliance */
-	NRFX_ASSERT((nsc_size & (nsc_size - 1)) == 0);
+    /* Check Non-Secure Callable region power-of-2 size compliance */
+    NRFX_ASSERT((nsc_size & (nsc_size - 1)) == 0);
 
-	/* Check Non-Secure Callable region size is within [32, 4096] range */
-	NRFX_ASSERT((nsc_size >= 32) && (nsc_size <= 4096));
+    /* Check Non-Secure Callable region size is within [32, 4096] range */
+    NRFX_ASSERT((nsc_size >= 32) && (nsc_size <= 4096));
 
-	nrf_spu_flashnsc_set(NRF_SPU, 0,
-		FLASH_NSC_SIZE_REG(nsc_size),
-		FLASH_NSC_REGION_FROM_ADDR(start_addr),
-		1 /* Lock */);
+    nrf_spu_flashnsc_set(NRF_SPU, 0,
+        FLASH_NSC_SIZE_REG(nsc_size),
+        FLASH_NSC_REGION_FROM_ADDR(start_addr),
+        1 /* Lock */);
 }
 
 uint32_t spu_regions_flash_get_base_address_in_region(uint32_t region_id)
 {
-	return FLASH_BASE_ADDRESS +
-		((region_id - FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID) *
-			FLASH_SECURE_ATTRIBUTION_REGION_SIZE);
+    return FLASH_BASE_ADDRESS +
+        ((region_id - FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID) *
+            FLASH_SECURE_ATTRIBUTION_REGION_SIZE);
 }
 
 uint32_t spu_regions_flash_get_last_address_in_region(uint32_t region_id)
 {
-	return FLASH_BASE_ADDRESS +
-		((region_id - FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID + 1) *
-			FLASH_SECURE_ATTRIBUTION_REGION_SIZE) - 1;
+    return FLASH_BASE_ADDRESS +
+        ((region_id - FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID + 1) *
+            FLASH_SECURE_ATTRIBUTION_REGION_SIZE) - 1;
 }
 
 uint32_t spu_regions_flash_get_start_id(void) {
 
-	return FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID;
+    return FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID;
 }
 
 uint32_t spu_regions_flash_get_last_id(void) {
 
-	return FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID +
-		NUM_FLASH_SECURE_ATTRIBUTION_REGIONS - 1;
+    return FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID +
+        NUM_FLASH_SECURE_ATTRIBUTION_REGIONS - 1;
 }
 
 uint32_t spu_regions_flash_get_region_size(void) {
 
-	return FLASH_SECURE_ATTRIBUTION_REGION_SIZE;
+    return FLASH_SECURE_ATTRIBUTION_REGION_SIZE;
 }
 
 uint32_t spu_regions_sram_get_base_address_in_region(uint32_t region_id)
 {
-	return SRAM_BASE_ADDRESS +
-		((region_id - SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID) *
-			SRAM_SECURE_ATTRIBUTION_REGION_SIZE);
+    return SRAM_BASE_ADDRESS +
+        ((region_id - SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID) *
+            SRAM_SECURE_ATTRIBUTION_REGION_SIZE);
 }
 
 uint32_t spu_regions_sram_get_last_address_in_region(uint32_t region_id)
 {
-	return SRAM_BASE_ADDRESS +
-		((region_id - SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID + 1) *
-			SRAM_SECURE_ATTRIBUTION_REGION_SIZE) - 1;
+    return SRAM_BASE_ADDRESS +
+        ((region_id - SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID + 1) *
+            SRAM_SECURE_ATTRIBUTION_REGION_SIZE) - 1;
 }
 
 uint32_t spu_regions_sram_get_start_id(void) {
 
-	return SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID;
+    return SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID;
 }
 
 uint32_t spu_regions_sram_get_last_id(void) {
 
-	return SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID +
-		NUM_SRAM_SECURE_ATTRIBUTION_REGIONS - 1;
+    return SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID +
+        NUM_SRAM_SECURE_ATTRIBUTION_REGIONS - 1;
 }
 
 uint32_t spu_regions_sram_get_region_size(void) {
 
-	return SRAM_SECURE_ATTRIBUTION_REGION_SIZE;
+    return SRAM_SECURE_ATTRIBUTION_REGION_SIZE;
 }
 
 void spu_peripheral_config_secure(uint32_t periph_base_addr, bool periph_lock)
 {
-	/* Determine peripheral ID */
-	const uint8_t periph_id = NRFX_PERIPHERAL_ID_GET(periph_base_addr);
+    /* Determine peripheral ID */
+    const uint8_t periph_id = NRFX_PERIPHERAL_ID_GET(periph_base_addr);
 
-	/* ASSERT checking that this is not an explicit Non-Secure peripheral */
-	NRFX_ASSERT((NRF_SPU->PERIPHID[periph_id].PERM &
-		SPU_PERIPHID_PERM_SECUREMAPPING_Msk) !=
-		(SPU_PERIPHID_PERM_SECUREMAPPING_NonSecure <<
-			SPU_PERIPHID_PERM_SECUREMAPPING_Pos));
+    /* ASSERT checking that this is not an explicit Non-Secure peripheral */
+    NRFX_ASSERT((NRF_SPU->PERIPHID[periph_id].PERM &
+        SPU_PERIPHID_PERM_SECUREMAPPING_Msk) !=
+        (SPU_PERIPHID_PERM_SECUREMAPPING_NonSecure <<
+            SPU_PERIPHID_PERM_SECUREMAPPING_Pos));
 
-	nrf_spu_peripheral_set(NRF_SPU, periph_id,
-		1 /* Secure */,
-		1 /* Secure DMA */,
-		periph_lock);
+    nrf_spu_peripheral_set(NRF_SPU, periph_id,
+        1 /* Secure */,
+        1 /* Secure DMA */,
+        periph_lock);
 }
 
 void spu_peripheral_config_non_secure(uint32_t periph_base_addr, bool periph_lock)
 {
-	/* Determine peripheral ID */
-	const uint8_t periph_id = NRFX_PERIPHERAL_ID_GET(periph_base_addr);
+    /* Determine peripheral ID */
+    const uint8_t periph_id = NRFX_PERIPHERAL_ID_GET(periph_base_addr);
 
-	/* ASSERT checking that this is not an explicit Secure peripheral */
-	NRFX_ASSERT((NRF_SPU->PERIPHID[periph_id].PERM &
-		SPU_PERIPHID_PERM_SECUREMAPPING_Msk) !=
-		(SPU_PERIPHID_PERM_SECUREMAPPING_Secure <<
-			SPU_PERIPHID_PERM_SECUREMAPPING_Pos));
+    /* ASSERT checking that this is not an explicit Secure peripheral */
+    NRFX_ASSERT((NRF_SPU->PERIPHID[periph_id].PERM &
+        SPU_PERIPHID_PERM_SECUREMAPPING_Msk) !=
+        (SPU_PERIPHID_PERM_SECUREMAPPING_Secure <<
+            SPU_PERIPHID_PERM_SECUREMAPPING_Pos));
 
-	nrf_spu_peripheral_set(NRF_SPU, periph_id,
-		0 /* Non-Secure */,
-		0 /* Non-Secure DMA */,
-		periph_lock);
+    nrf_spu_peripheral_set(NRF_SPU, periph_id,
+        0 /* Non-Secure */,
+        0 /* Non-Secure DMA */,
+        periph_lock);
 }

--- a/platform/ext/target/nordic_nrf/nrf5340/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/nrf5340/target_cfg.c
@@ -207,53 +207,53 @@ enum tfm_plat_err_t spu_init_cfg(void)
 
 enum tfm_plat_err_t spu_periph_init_cfg(void)
 {
-	/* Peripheral configuration */
-	spu_peripheral_config_non_secure((uint32_t)NRF_REGULATORS, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_CLOCK, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_SPIM0, false);
+    /* Peripheral configuration */
+    spu_peripheral_config_non_secure((uint32_t)NRF_REGULATORS, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_CLOCK, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM0, false);
 #ifndef SECURE_UART1
-	/* UART1 is a secure peripheral, so we need to leave Serial-Box 1 as Secure */
-	spu_peripheral_config_non_secure((uint32_t)NRF_SPIM1, false);
+    /* UART1 is a secure peripheral, so we need to leave Serial-Box 1 as Secure */
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM1, false);
 #endif
-	spu_peripheral_config_non_secure((uint32_t)NRF_SPIM4, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_SAADC, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_TIMER0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_TIMER1, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_TIMER2, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_RTC0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_RTC1, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_DPPIC, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_WDT0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_COMP, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU1, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU2, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU3, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU4, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU5, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_PWM0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_PWM1, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_PWM2, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_PDM0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_I2S0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_IPC, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_QSPI, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_NFCT, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_GPIOTE1_NS, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_MUTEX, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_NVMC, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_P0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_P1, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_VMC, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM4, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_SAADC, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_TIMER0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_TIMER1, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_TIMER2, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_RTC0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_RTC1, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_DPPIC, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_WDT0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_COMP, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU1, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU2, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU3, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU4, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU5, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM1, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM2, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_PDM0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_I2S0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_IPC, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_QSPI, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_NFCT, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_GPIOTE1_NS, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_MUTEX, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_NVMC, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_P0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_P1, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_VMC, false);
 
-	/* DPPI channel configuration */
-	spu_dppi_config_non_secure(false);
+    /* DPPI channel configuration */
+    spu_dppi_config_non_secure(false);
 
-	/* GPIO pin configuration (P0 and P1 ports) */
-	spu_gpio_config_non_secure(0, false);
-	spu_gpio_config_non_secure(1, false);
+    /* GPIO pin configuration (P0 and P1 ports) */
+    spu_gpio_config_non_secure(0, false);
+    spu_gpio_config_non_secure(1, false);
 
-	return TFM_PLAT_ERR_SUCCESS;
+    return TFM_PLAT_ERR_SUCCESS;
 }
 
 void spu_periph_configure_to_secure(uint32_t periph_num)

--- a/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
@@ -26,7 +26,7 @@
  * the Cortex-M33 core, memory permissions and security attribution
  * on the nRF5340 platform.
  *
- * Memory permisssions and security attribution are configured via
+ * Memory permissions and security attribution are configured via
  * the System Protection Unit (SPU) which is the nRF specific Implementation
  * Defined Attribution Unit (IDAU).
  */

--- a/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
@@ -18,6 +18,20 @@
 #ifndef __TARGET_CFG_H__
 #define __TARGET_CFG_H__
 
+/**
+ * \file target_cfg.h
+ * \brief nRF5340 target configuration header
+ *
+ * This file contains the platform specific functions to configure
+ * the Cortex-M33 core, memory permissions and security attribution
+ * on the nRF5340 platform.
+ *
+ * Memory permisssions and security attribution are configured via
+ * the System Protection Unit (SPU) which is the nRF specific Implementation
+ * Defined Attribution Unit (IDAU).
+ */
+
+
 #include "tfm_plat_defs.h"
 
 #define TFM_DRIVER_STDIO    Driver_USART1

--- a/platform/ext/target/nordic_nrf/nrf9160/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/nrf9160/target_cfg.c
@@ -23,17 +23,15 @@
 #include <spu.h>
 #include <nrfx.h>
 
-
 struct tfm_spm_partition_platform_data_t tfm_peripheral_timer0 = {
-        NRF_TIMER0_S_BASE,
-        NRF_TIMER0_S_BASE + (sizeof(NRF_TIMER_Type) - 1),
+    NRF_TIMER0_S_BASE,
+    NRF_TIMER0_S_BASE + (sizeof(NRF_TIMER_Type) - 1),
 };
 
 struct tfm_spm_partition_platform_data_t tfm_peripheral_std_uart = {
-        NRF_UARTE1_S_BASE,
-        NRF_UARTE1_S_BASE + (sizeof(NRF_UARTE_Type) - 1),
+    NRF_UARTE1_S_BASE,
+    NRF_UARTE1_S_BASE + (sizeof(NRF_UARTE_Type) - 1),
 };
-
 
 /* The section names come from the scatter file */
 REGION_DECLARE(Load$$LR$$, LR_NS_PARTITION, $$Base);
@@ -83,9 +81,9 @@ enum tfm_plat_err_t enable_fault_handlers(void)
 
     /* Enables BUS, MEM, USG and Secure faults */
     SCB->SHCSR |= SCB_SHCSR_USGFAULTENA_Msk
-                  | SCB_SHCSR_BUSFAULTENA_Msk
-                  | SCB_SHCSR_MEMFAULTENA_Msk
-                  | SCB_SHCSR_SECUREFAULTENA_Msk;
+        | SCB_SHCSR_BUSFAULTENA_Msk
+        | SCB_SHCSR_MEMFAULTENA_Msk
+        | SCB_SHCSR_SECUREFAULTENA_Msk;
     return TFM_PLAT_ERR_SUCCESS;
 }
 
@@ -172,17 +170,17 @@ enum tfm_plat_err_t spu_init_cfg(void)
 
     /* Configures SPU Code and Data regions to be non-secure */
     spu_regions_flash_config_non_secure(memory_regions.non_secure_partition_base,
-        memory_regions.non_secure_partition_limit);
+                                        memory_regions.non_secure_partition_limit);
     spu_regions_sram_config_non_secure(NS_DATA_START, NS_DATA_LIMIT);
 
     /* Configures veneers region to be non-secure callable */
     spu_regions_flash_config_non_secure_callable(memory_regions.veneer_base,
-        memory_regions.veneer_limit - 1);
+                                                 memory_regions.veneer_limit - 1);
 
 #ifdef BL2
     /* Secondary image partition */
     spu_regions_flash_config_non_secure(memory_regions.secondary_partition_base,
-        memory_regions.secondary_partition_limit);
+                                        memory_regions.secondary_partition_limit);
 #endif /* BL2 */
 
     return TFM_PLAT_ERR_SUCCESS;
@@ -190,49 +188,49 @@ enum tfm_plat_err_t spu_init_cfg(void)
 
 enum tfm_plat_err_t spu_periph_init_cfg(void)
 {
-	/* Peripheral configuration */
-	spu_peripheral_config_non_secure((uint32_t)NRF_REGULATORS, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_CLOCK, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_SPIM0, false);
+    /* Peripheral configuration */
+    spu_peripheral_config_non_secure((uint32_t)NRF_REGULATORS, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_CLOCK, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM0, false);
 #ifndef SECURE_UART1
-	/* UART1 is a secure peripheral, so we need to leave Serial-Box 1 as Secure */
-	spu_peripheral_config_non_secure((uint32_t)NRF_SPIM1, false);
+    /* UART1 is a secure peripheral, so we need to leave Serial-Box 1 as Secure */
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM1, false);
 #endif
-	spu_peripheral_config_non_secure((uint32_t)NRF_SPIM2, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_SPIM3, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_SAADC, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_TIMER0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_TIMER1, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_TIMER2, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_RTC0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_RTC1, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_DPPIC, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_WDT, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU1, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU2, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU3, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU4, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_EGU5, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_PWM0, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_PWM1, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_PWM2, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_PWM2, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_PDM, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_I2S, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_IPC, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_GPIOTE1_NS, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_NVMC, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_VMC, false);
-	spu_peripheral_config_non_secure((uint32_t)NRF_P0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM2, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM3, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_SAADC, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_TIMER0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_TIMER1, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_TIMER2, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_RTC0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_RTC1, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_DPPIC, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_WDT, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU1, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU2, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU3, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU4, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU5, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM0, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM1, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM2, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM2, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_PDM, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_I2S, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_IPC, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_GPIOTE1_NS, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_NVMC, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_VMC, false);
+    spu_peripheral_config_non_secure((uint32_t)NRF_P0, false);
 
-	/* DPPI channel configuration */
-	spu_dppi_config_non_secure(false);
+    /* DPPI channel configuration */
+    spu_dppi_config_non_secure(false);
 
-	/* GPIO pin configuration */
-	spu_gpio_config_non_secure(0, false);
+    /* GPIO pin configuration */
+    spu_gpio_config_non_secure(0, false);
 
-	return TFM_PLAT_ERR_SUCCESS;
+    return TFM_PLAT_ERR_SUCCESS;
 }
 
 void spu_periph_configure_to_secure(uint32_t periph_num)

--- a/platform/ext/target/nordic_nrf/nrf9160/target_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf9160/target_cfg.h
@@ -18,6 +18,19 @@
 #ifndef __TARGET_CFG_H__
 #define __TARGET_CFG_H__
 
+/**
+ * \file target_cfg.h
+ * \brief nRF9160 target configuration header
+ *
+ * This file contains the platform specific functions to configure
+ * the Cortex-M33 core, memory permissions and security attribution
+ * on the nRF9160 platform.
+ *
+ * Memory permisssions and security attribution are configured via
+ * the System Protection Unit (SPU) which is the nRF specific Implementation
+ * Defined Attribution Unit (IDAU).
+ */
+
 #include "tfm_plat_defs.h"
 
 #define TFM_DRIVER_STDIO    Driver_USART1

--- a/platform/ext/target/nordic_nrf/nrf9160/target_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf9160/target_cfg.h
@@ -26,7 +26,7 @@
  * the Cortex-M33 core, memory permissions and security attribution
  * on the nRF9160 platform.
  *
- * Memory permisssions and security attribution are configured via
+ * Memory permissions and security attribution are configured via
  * the System Protection Unit (SPU) which is the nRF specific Implementation
  * Defined Attribution Unit (IDAU).
  */


### PR DESCRIPTION
…to spaces

Adding brief descriptions in target_cfg.h headers to clarify
the SPU terminology.

Convert tabs to spaces in source files as requested.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>